### PR TITLE
Fix syntax error when calling getTransactionHistory or getNotificationHistory

### DIFF
--- a/src/Response/PageableResponse.php
+++ b/src/Response/PageableResponse.php
@@ -62,7 +62,8 @@ abstract class PageableResponse extends AbstractResponse
                 $queryParams = $page->originalRequest->getQueryParams();
 
                 if (is_subclass_of($queryParams, PageableQueryParams::class)) {
-                    $nextRequest = new (get_class($page->originalRequest))(
+                    $class = get_class($queryParams);
+                    $nextRequest = new $class(
                         $page->originalRequest->getKey(),
                         $page->originalRequest->getPayload(),
                         $queryParams->forRevision($page->revision),


### PR DESCRIPTION
when calling getTransactionHistory or getNotificationHistory we receive the error

`// ParseError: syntax error, unexpected '(' in file /var/www/app/vendor/readdle/app-store-server-api/src/Response/PageableResponse.php on line 65`

The line in the file is:
```
$nextRequest = new (get_class($page->originalRequest))(...
```

request that this could please be updated to:
```
$class = get_class($queryParams);
$nextRequest = new $class(
```

which seems to fix the issue. 