### PR TITLE
Update HTTPRequest.php

### DIFF
--- a/src/HTTPRequest.php
+++ b/src/HTTPRequest.php
@@ -68,7 +68,7 @@ final class HTTPRequest
 
         $statusCode = (int) $matches['statusCode'];
 
-        if ($statusCode !== 200) {
+        if ($statusCode >= 400) {
             throw new HTTPRequestFailed($httpMethod, $url, $response, $statusCode);
         }
 


### PR DESCRIPTION
Status codes below 300 are valid. And status codes in the 300s are redirections or similar tasks for the client side. So, a exception for all status codes not equal to 200 is wrong.

The main problem here is that the "Send Consumtion Information" endpoint returns a 202 under normal circumstances:

https://developer.apple.com/documentation/appstoreserverapi/send_consumption_information#response-codes