### PR TITLE
Version 3.6.2 - If the certificate string already has a prefix, there is no need to add it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"php"
 	],
 	"homepage": "https://github.com/readdle/app-store-server-api",
-	"version": "3.6.1",
+	"version": "3.6.2",
 	"php": ">=7.4",
 	"autoload": {
 		"psr-4": {

--- a/src/Util/Helper.php
+++ b/src/Util/Helper.php
@@ -70,7 +70,7 @@ final class Helper
 
     public static function formatPEM(string $certificate): string
     {
-        if (strrpos($certificate, "-----BEGIN CERTIFICATE-----\n") !== false) {
+        if (strpos($certificate, "-----BEGIN CERTIFICATE-----\n") !== false) {
             return $certificate;
         }
 

--- a/src/Util/Helper.php
+++ b/src/Util/Helper.php
@@ -70,6 +70,10 @@ final class Helper
 
     public static function formatPEM(string $certificate): string
     {
+        if (strrpos($certificate, "-----BEGIN CERTIFICATE-----\n") !== false) {
+            return $certificate;
+        }
+
         return join("\n", [
             "-----BEGIN CERTIFICATE-----",
             $certificate,


### PR DESCRIPTION
Changes:
- Added fix for `Readdle\AppStoreServerAPI\Util::formatPEM()` method. If the certificate string already has a prefix, there is no need to add it;
- Minor version update: `v3.6.1` -> `v3.6.2` .