### PR TITLE
Fixes composer install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a ***zero-dependencies\* pure PHP*** library that allows managing custom
 
 Nothing special here, just use composer to install the package:
 
-> composer install readdle/app-store-server-api
+> composer require readdle/app-store-server-api
 
 # Usage
 


### PR DESCRIPTION
In the readme the wrong composer command is specified. `composer install` doesn't add new dependency, but install already existing in the `composer.json`