### PR TITLE
added support GetTransactionHistoryRequest V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,19 @@ For `Order ID lookup` you have to specify `orderId`. This endpoint (and, consequ
 
 # What is covered
 
-### In-app purchase history
+### In-app purchase history V1 (Deprecated, but left for backwards compatibility)
+
+#### [Get Transaction History](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history_v1)
+
+`AppStoreServerAPI::getTransactionHistory(string $transactionId, array $queryParams)`
+
+Get a customer’s in-app purchase transaction history for your app.
+
+### In-app purchase history V2
 
 #### [Get Transaction History](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history)
 
-`AppStoreServerAPI::getTransactionHistory(string $transactionId, array $queryParams)`
+`AppStoreServerAPI::getTransactionHistoryV2(string $transactionId, array $queryParams)`
 
 Get a customer’s in-app purchase transaction history for your app.
 

--- a/src/AppStoreServerAPI.php
+++ b/src/AppStoreServerAPI.php
@@ -18,6 +18,7 @@ use Readdle\AppStoreServerAPI\Request\GetRefundHistoryRequest;
 use Readdle\AppStoreServerAPI\Request\GetStatusOfSubscriptionRenewalDateExtensionsRequest;
 use Readdle\AppStoreServerAPI\Request\GetTestNotificationStatusRequest;
 use Readdle\AppStoreServerAPI\Request\GetTransactionHistoryRequest;
+use Readdle\AppStoreServerAPI\Request\GetTransactionHistoryRequestV2;
 use Readdle\AppStoreServerAPI\Request\GetTransactionInfoRequest;
 use Readdle\AppStoreServerAPI\Request\LookUpOrderIdRequest;
 use Readdle\AppStoreServerAPI\Request\MassExtendSubscriptionRenewalDateRequest;
@@ -80,6 +81,20 @@ final class AppStoreServerAPI implements AppStoreServerAPIInterface
          */
         $response = $this->performRequest(
             GetTransactionHistoryRequest::class,
+            HistoryResponse::class,
+            ['transactionId' => $transactionId],
+            new GetTransactionHistoryQueryParams($queryParams)
+        );
+        return $response;
+    }
+
+    public function getTransactionHistoryV2(string $transactionId, array $queryParams = []): HistoryResponse
+    {
+        /**
+         * @var HistoryResponse $response
+         */
+        $response = $this->performRequest(
+            GetTransactionHistoryRequestV2::class,
             HistoryResponse::class,
             ['transactionId' => $transactionId],
             new GetTransactionHistoryQueryParams($queryParams)

--- a/src/Request/GetTransactionHistoryRequestV2.php
+++ b/src/Request/GetTransactionHistoryRequestV2.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Readdle\AppStoreServerAPI\Request;
+
+class GetTransactionHistoryRequestV2 extends AbstractRequest
+{
+    public function getHTTPMethod(): string
+    {
+        return self::HTTP_METHOD_GET;
+    }
+
+    protected function getURLPattern(): string
+    {
+        return '{baseUrl}/v2/history/{transactionId}';
+    }
+}


### PR DESCRIPTION
Apple deprecated endpoint
GET https://api.storekit.itunes.apple.com/inApps/**v1**/history/{transactionId}

[documentation link - Get Transaction History V1](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history_v1)

Actual endpoint
GET https://api.storekit.itunes.apple.com/inApps/**v2**/history/{transactionId}

[documentation link - Get Transaction History](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history)

changes:
- added new Request for v2
- added new method for use v2 Request
- updated readme

i added new method, and don't change old method for backwards compatibility


