### PR TITLE
3.12.0 - Add notification type ONE_TIME_CHARGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### [3.12.0] 2025/05/22
+
+**IMPROVEMENTS:**
+
+- New `notificationType` = `ONE_TIME_CHARGE` in `ResponseBodyV2`
+
 ### [3.11.1] 2025/03/24
 
 **BUGFIX:**

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"php"
 	],
 	"homepage": "https://github.com/readdle/app-store-server-api",
-	"version": "3.11.1",
+	"version": "3.12.0",
 	"php": ">=7.4",
 	"autoload": {
 		"psr-4": {

--- a/src/ResponseBodyV2.php
+++ b/src/ResponseBodyV2.php
@@ -171,6 +171,13 @@ final class ResponseBodyV2 implements JsonSerializable
     const NOTIFICATION_TYPE__SUBSCRIBED = 'SUBSCRIBED';
 
     /**
+     * A notification type that indicates the customer purchased a consumable, non-consumable, or non-renewing
+     * subscription. The App Store also sends this notification when the customer receives access to a non-consumable
+     * product through Family Sharing.
+     */
+    const NOTIFICATION_TYPE__ONE_TIME_CHARGE = 'ONE_TIME_CHARGE';
+
+    /**
      * A notification type that the App Store server sends when you request it by calling the Request a Test
      * Notification endpoint. Call that endpoint to test whether your server is receiving notifications. You receive
      * this notification only at your request. For troubleshooting information, see


### PR DESCRIPTION
Added a new notification type [ONE_TIME_CHARGE](https://developer.apple.com/documentation/appstoreservernotifications/notificationtype)