### PR TITLE
fix(composer): Fix psr-4 invalid namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"Readdle\\AppStoreServerAPI\\Tests": "tests/"
+			"Readdle\\AppStoreServerAPI\\Tests\\": "tests/"
 		}
 	},
 	"require": {


### PR DESCRIPTION
**Fix PSR-4 test namespace missing trailing backslash in composer.json**                                                                                                                                             
                                                                                                                                                                                                                   
  **Problem**                                                                
                                                                                                                                                                                                                   
  The autoload-dev section of composer.json declared the test namespace without the required trailing namespace separator:                                                                                         
                                                                                                                                                                                                                   
```
  "autoload-dev": {                                                                                                                                                                                                
      "psr-4": {                                                                                                                                                                                                   
          "Readdle\\AppStoreServerAPI\\Tests": "tests/"                                                                                                                                                            
      }                                                                                                                                                                                                            
  }

```

According to the PSR-4 specification and Composer's implementation, all namespace prefixes must end with a backslash (\). Without it, Composer throws a fatal error when generating the autoloader:

```
  In ClassLoader.php line 305:
  A non-empty PSR-4 prefix must end with a namespace separator.
```

  This made it impossible to run composer install (or composer dump-autoload) successfully, completely breaking the test suite bootstrap.

  Fix

  Added the missing trailing backslash to the namespace prefix:

```
  "autoload-dev": {
      "psr-4": {
          "Readdle\\AppStoreServerAPI\\Tests\\": "tests/"
      }
  }
```

  Impact

  Without this fix, vendor/autoload.php was never generated, causing all PHPUnit tests to fail at the bootstrap stage regardless of their content.


