### PR TITLE
fix: cast integer values to string before rawurlencode in query string builder

### DIFF
--- a/src/RequestQueryParams/AbstractRequestQueryParams.php
+++ b/src/RequestQueryParams/AbstractRequestQueryParams.php
@@ -24,6 +24,8 @@ abstract class AbstractRequestQueryParams extends AbstractRequestParamsBag
                 );
             } elseif (is_bool($value)) {
                 $queryStringParams[] = $propName . '=' . ($value ? 'true' : 'false');
+            } elseif (is_int($value)) {
+                $queryStringParams[] = $propName . '=' . $value;
             } else {
                 $queryStringParams[] = $propName . '=' . rawurlencode($value);
             }

--- a/tests/Unit/RequestQueryParams/GetTransactionHistoryQueryParamsTest.php
+++ b/tests/Unit/RequestQueryParams/GetTransactionHistoryQueryParamsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Readdle\AppStoreServerAPI\Tests\Unit\RequestQueryParams;
+
+use PHPUnit\Framework\TestCase;
+use Readdle\AppStoreServerAPI\RequestQueryParams\GetTransactionHistoryQueryParams;
+
+final class GetTransactionHistoryQueryParamsTest extends TestCase
+{
+    public function testDefaultsProduceEmptyQueryString(): void
+    {
+        $params = new GetTransactionHistoryQueryParams();
+
+        $this->assertSame('', $params->getQueryString());
+    }
+
+    public function testArrayParamProducesRepeatedKeys(): void
+    {
+        $params = new GetTransactionHistoryQueryParams(['productId' => ['com.example.monthly', 'com.example.yearly']]);
+
+        $this->assertSame('productId=com.example.monthly&productId=com.example.yearly', $params->getQueryString());
+    }
+
+    public function testArrayParamValuesAreUrlEncoded(): void
+    {
+        $params = new GetTransactionHistoryQueryParams(['productId' => ['com.example app', 'com.example/other']]);
+
+        $this->assertSame('productId=com.example%20app&productId=com.example%2Fother', $params->getQueryString());
+    }
+
+    public function testBoolParamRenderedAsTrue(): void
+    {
+        $params = new GetTransactionHistoryQueryParams(['excludeRevoked' => true]);
+
+        $this->assertSame('excludeRevoked=true', $params->getQueryString());
+    }
+
+    public function testIntParamIsRenderedWithoutEncoding(): void
+    {
+        $params = new GetTransactionHistoryQueryParams(['startDate' => 1700000000000]);
+
+        $this->assertSame('startDate=1700000000000', $params->getQueryString());
+    }
+
+    public function testStringParamIsUrlEncoded(): void
+    {
+        $params = new GetTransactionHistoryQueryParams(['inAppOwnershipType' => 'FAMILY SHARED']);
+
+        $this->assertSame('inAppOwnershipType=FAMILY%20SHARED', $params->getQueryString());
+    }
+
+    public function testMultipleParamsAreJoinedWithAmpersand(): void
+    {
+        $params = new GetTransactionHistoryQueryParams([
+            'startDate' => 1700000000000,
+            'endDate' => 1710000000000,
+            'productId' => ['com.example.monthly'],
+            'excludeRevoked' => true,
+        ]);
+
+        $this->assertSame(
+            'startDate=1700000000000&endDate=1710000000000&productId=com.example.monthly&excludeRevoked=true',
+            $params->getQueryString()
+        );
+    }
+}


### PR DESCRIPTION
**Fix rawurlencode() type error on integer query parameters**                                                   
                                                                                                                                                                                                                   
Fixes #34                                                                                                                                                                                          
                                                                                                                                                                                                                   
**Problem**                                                                                                                                                                                                          
                                                                                                
  When building a query string, integer values were passed directly to rawurlencode(), which expects a string. This caused a fatal error:

`
rawurlencode(): Argument #1 ($string) must be of type string, int given
`
  For example, GetTransactionHistoryQueryParams defines startDate and endDate as int (Unix timestamps). Passing them to getQueryString() triggered the error:

```
  $params = new GetTransactionHistoryQueryParams();
  $params->startDate = 1700000000;
  $params->endDate   = 1710000000;

  $params->getQueryString(); // ❌ Fatal error: rawurlencode() expects string, int given
```
  **Solution**

  Added an explicit is_int check in AbstractRequestQueryParams::getQueryString() so integer values are appended directly without going through rawurlencode(), consistent with how booleans are already handled.

```
  } elseif (is_int($value)) {
      $queryStringParams[] = $propName . '=' . $value;
  }
```

  **Changes**

  - src/RequestQueryParams/AbstractRequestQueryParams.php — added elseif (is_int($value)) branch to handle integer query parameters safely
