### PR TITLE
Fix implicitly marking parameter in JWTCreationException

### DIFF
--- a/src/Exception/JWTCreationException.php
+++ b/src/Exception/JWTCreationException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 final class JWTCreationException extends AppStoreServerAPIException
 {
-    public function __construct(string $message, Throwable $previous = null)
+    public function __construct(string $message, ?Throwable $previous = null)
     {
         parent::__construct("JWT creation error: $message", 0, $previous);
     }


### PR DESCRIPTION
This PR fixed "implicitly marking parameter" warning when app using PHP 8.4:

```
PHP Deprecated: Readdle\AppStoreServerAPI\Exception\JWTCreationException::__construct(): 
Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/readdle/app-store-server-api/src/Exception/JWTCreationException.php on line 10
```