### PR TITLE
feat: Add function for creating ResponseBodyV2 from signedPayload

### DIFF
--- a/src/NotificationHistoryResponseItem.php
+++ b/src/NotificationHistoryResponseItem.php
@@ -36,7 +36,7 @@ final class NotificationHistoryResponseItem implements JsonSerializable
         $this->signedPayload = $signedPayload;
 
         try {
-            $this->responseBodyV2 = ResponseBodyV2::createFromRawNotification("{\"signedPayload\":\"$signedPayload\"}");
+            $this->responseBodyV2 = ResponseBodyV2::createFromSignedPayload($signedPayload);
         } catch (AppStoreServerNotificationException $e) {
             // nothing to do with this hypothetical situation
         }

--- a/src/ResponseBodyV2.php
+++ b/src/ResponseBodyV2.php
@@ -342,8 +342,16 @@ final class ResponseBodyV2 implements JsonSerializable
             throw new AppStoreServerNotificationException('Notification does not contain "signedPayload" property');
         }
 
+        return self::createFromSignedPayload($notification['signedPayload'], $rootCertificate);
+    }
+
+    /**
+     * @throws AppStoreServerNotificationException
+     */
+    public static function createFromSignedPayload(string $signedPayload, ?string $rootCertificate = null): self
+    {
         try {
-            $payload = JWT::parse($notification['signedPayload'], $rootCertificate);
+            $payload = JWT::parse($signedPayload, $rootCertificate);
         } catch (MalformedJWTException $e) {
             throw new AppStoreServerNotificationException('Malformed JWT: ' . $e->getMessage());
         }


### PR DESCRIPTION
This separates the concerns of parsing an incoming JSON document from processing the actual payload.

This is also useful when dealing with payloads from other origins, such as the Notification history endpoint.