### PR TITLE
v3.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,40 @@
 .PHONY: shell
 
+COMPOSER_VER = 2.9.5
+PHP_VER = 8.2.32
+
+cs-check:
+	docker run -t --rm -w /app -v .:/app php:${PHP_VER}-cli php vendor/bin/php-cs-fixer fix --dry-run --diff --verbose
+
+composer:
+	docker run --rm -it -v $(shell pwd):/app -w /app composer:${COMPOSER_VER} bash
+
+lint-74:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:7.4-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
+lint-80:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:8.0-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
+lint-81:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:8.1-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
+lint-82:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:8.2-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
+lint-83:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:8.3-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
+lint-84:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:8.4-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
+lint-85:
+	docker run --rm -it -v $(shell pwd):/app -w /app php:8.5-cli bash -c 'OUT=$$(find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l | grep -v "No syntax errors detected in "); echo "$$OUT"; [ -z "$$OUT" ]'
+
 shell:
-	docker run --rm -it -w /app/examples -v $(shell pwd):/app php:8.4.11-cli bash
+	docker run --rm -it -w /app/examples -v $(shell pwd):/app php:8.5.2-cli bash
+
+stan:
+	docker run -t --rm -w /app -v .:/app php:${PHP_VER}-cli php -d memory_limit=256M vendor/bin/phpstan
+
+test:
+	docker run -t --rm -w /app -v .:/app php:${PHP_VER}-cli php vendor/bin/phpunit

--- a/src/AppMetadata.php
+++ b/src/AppMetadata.php
@@ -30,7 +30,7 @@ final class AppMetadata implements JsonSerializable
 
     /**
      * The reason the customer requested the refund.
-     * 
+     *
      * This field appears only for CONSUMPTION_REQUEST notifications.
      */
     private ?string $consumptionRequestReason = null;

--- a/src/AppStoreServerAPI.php
+++ b/src/AppStoreServerAPI.php
@@ -142,12 +142,12 @@ final class AppStoreServerAPI implements AppStoreServerAPIInterface
         );
     }
 
-    public function setAppAccountToken(string $transactionId, array $requestBody): void
+    public function setAppAccountToken(string $originalTransactionId, array $requestBody): void
     {
         $this->performRequest(
             SetAppAccountTokenRequest::class,
             null,
-            ['transactionId' => $transactionId],
+            ['originalTransactionId' => $originalTransactionId],
             null,
             new UpdateAppAccountTokenRequestBody($requestBody)
         );

--- a/src/AppStoreServerAPIInterface.php
+++ b/src/AppStoreServerAPIInterface.php
@@ -39,6 +39,17 @@ interface AppStoreServerAPIInterface
     public function getTransactionHistory(string $transactionId, array $queryParams = []): HistoryResponse;
 
     /**
+     * Get a customer's in-app purchase transaction history for your app
+     *
+     * @param string $transactionId The identifier of a transaction that belongs to the customer, and which may be an
+     * original transaction identifier
+     * @param array<string, mixed> $queryParams [optional] Query Parameters
+     *
+     * @throws AppStoreServerAPIException
+     */
+    public function getTransactionHistoryV2(string $transactionId, array $queryParams = []): HistoryResponse;
+
+    /**
      * Get information about a single transaction for your app.
      *
      * @param string $transactionId The identifier of a transaction that belongs to the customer, and which may be an
@@ -70,6 +81,18 @@ interface AppStoreServerAPIInterface
      * @throws AppStoreServerAPIException
      */
     public function sendConsumptionInformation(string $transactionId, array $requestBody): void;
+
+    /**
+     * Sets the app account token value for a purchase the customer makes outside of your app
+     * or updates its value in an existing transaction.
+     *
+     * @param string $originalTransactionId The original transaction identifier of the transaction to receive the app
+     * account token update.
+     * @param array<string, int|string> $requestBody The request body that contains a valid app account token value.
+     *
+     * @throws AppStoreServerAPIException
+     */
+    public function setAppAccountToken(string $originalTransactionId, array $requestBody): void;
 
     /**
      * Get a customer's in-app purchases from a receipt using the order ID.

--- a/src/Exception/JWTCreationException.php
+++ b/src/Exception/JWTCreationException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 final class JWTCreationException extends AppStoreServerAPIException
 {
-    public function __construct(string $message, Throwable $previous = null)
+    public function __construct(string $message, ?Throwable $previous = null)
     {
         parent::__construct("JWT creation error: $message", 0, $previous);
     }

--- a/src/Request/SetAppAccountTokenRequest.php
+++ b/src/Request/SetAppAccountTokenRequest.php
@@ -12,6 +12,6 @@ final class SetAppAccountTokenRequest extends AbstractRequest
 
     protected function getURLPattern(): string
     {
-        return '{baseUrl}/v1/transactions/{transactionId}/appAccountToken';
+        return '{baseUrl}/v1/transactions/{originalTransactionId}/appAccountToken';
     }
 }

--- a/src/Util/JWT.php
+++ b/src/Util/JWT.php
@@ -197,6 +197,10 @@ final class JWT
      */
     private static function verifyX509Chain(array $chain, ?string $rootCertificate = null): void
     {
+        if (count($chain) !== 3) {
+            throw new Exception('Invalid X509 chain length');
+        }
+
         [$certificate, $intermediate, $root] = array_map([Helper::class, 'formatPEM'], $chain);
 
         if (openssl_x509_verify($certificate, $intermediate) !== 1) {


### PR DESCRIPTION
<!-- airbug-describe-start -->
## :rocket: Summary

- :sparkles: Add `getTransactionHistoryV2()` method to `AppStoreServerAPIInterface` for fetching in-app purchase transaction history via the v2 endpoint.
- :wrench: Fix `setAppAccountToken()` to use `originalTransactionId` (matching Apple's API contract) instead of `transactionId`, and expose it on the interface.
- :shield: Harden JWT X509 chain verification by rejecting chains that don't contain exactly 3 certificates.
- :hammer_and_wrench: Expand `Makefile` with Dockerized targets for `composer`, `cs-check`, `stan`, `test`, and multi-version PHP lint (7.4 – 8.5); bump shell PHP to 8.5.2.
- :broom: Minor cleanup: nullable type hint on `JWTCreationException::__construct()`, whitespace fix.

> [!IMPORTANT]
> `setAppAccountToken()` parameter renamed from `$transactionId` to `$originalTransactionId`. Callers using named arguments must be updated.
<!-- airbug-correlation:corr-d7132970-a885-11f1-9ce9-f9d758304b60 -->
<!-- airbug-describe-end -->